### PR TITLE
changing xml url to v2

### DIFF
--- a/slideslive-slides-dl.py
+++ b/slideslive-slides-dl.py
@@ -62,7 +62,7 @@ def download_slides_xml(base_xml_url, video_id, video_name, headers, wait_time):
 
     file_path = '{0}/{1}.xml'.format(folder_name, video_id)
     if not os.path.exists(file_path):
-        xml_url = '{0}{1}/{1}.xml'.format(base_xml_url, video_id)
+        xml_url = '{0}{1}/v2/{1}.xml'.format(base_xml_url, video_id)
         print('downloading {}'.format(file_path))
         download_save_file(xml_url, file_path, headers, wait_time)
 


### PR DESCRIPTION
Slideslive has changed the slides URL (e.g., "https://d2ygwrecguqg66.cloudfront.net/data/presentations/38938928/v2/38938928.xml?1604598345" )
![Screen Shot 2021-03-01 at 12 52 38 PM](https://user-images.githubusercontent.com/6125084/109464843-55990080-7a8d-11eb-9b41-f1843b8392ab.png)
